### PR TITLE
Small improvements to passing city to wttrin

### DIFF
--- a/wttrin.el
+++ b/wttrin.el
@@ -66,10 +66,10 @@
         (setq buffer-read-only t)))))
 
 ;;;###autoload
-(defun wttrin ()
-  "Display weather information."
-  (interactive)
-  (wttrin-query (completing-read "City name: " wttrin-default-cities nil nil)))
+(defun wttrin (city)
+  "Display weather information for CITY."
+  (interactive (list (completing-read "City name: " wttrin-default-cities nil nil)))
+  (wttrin-query city))
 
 (provide 'wttrin)
 

--- a/wttrin.el
+++ b/wttrin.el
@@ -68,7 +68,11 @@
 ;;;###autoload
 (defun wttrin (city)
   "Display weather information for CITY."
-  (interactive (list (completing-read "City name: " wttrin-default-cities nil nil)))
+  (interactive
+   (list
+    (completing-read "City name: " wttrin-default-cities nil nil
+                     (when (= (length wttrin-default-cities) 1)
+                       (car wttrin-default-cities)))))
   (wttrin-query city))
 
 (provide 'wttrin)


### PR DESCRIPTION
This PR contains a couple of small changes that I think slightly improve how `wttrin` accepts the city name.

1. The city name is now accepted as an argument to the function, so that it can be called from other code.
2. If only one city is defined in `wttrin-default-cities` the input to `wttrin`, when called interactively, will be visibly defaulted to that city name.