### PR TITLE
Add option for selecting the unit system

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ You can also specify default HTTP request Header for Accept-Language:
 (setq wttrin-default-accept-language '("Accept-Language" . "zh-TW"))
 ```
 
+As well as the unit system, "m" for metric and "u" for USCS/imperial (the default is to choose based on your location):
+
+```elisp
+(setq wttrin-unit-system "m")
+```
+
 Then run `M-x wttrin` to get the information.
 
 When the weather is displayed you can press `q` to quit the buffer or `g` to query for another city.

--- a/wttrin.el
+++ b/wttrin.el
@@ -33,13 +33,25 @@
   :type '(list)
   )
 
+(defcustom wttrin-unit-system "m"
+  "Specify the units.  use 'm' for 'metric', 'u' for 'USCS, or
+nil for location based"
+  :group 'wttrin
+  :type 'string
+  )
+
+(defun wttrin-additional-url-params ()
+  "Concatenate any extra stuff into the URL here."
+  (concat "?" wttrin-unit-system)
+  )
+
 (defun wttrin-fetch-raw-string (query)
   "Get the weather information based on your QUERY."
   (let ((url-request-extra-headers '(("User-Agent" . "curl"))))
     (add-to-list 'url-request-extra-headers wttrin-default-accept-language)
     (with-current-buffer
         (url-retrieve-synchronously
-         (concat "http://wttr.in/" query)
+         (concat "http://wttr.in/" query (wttrin-additional-url-params))
          (lambda (status) (switch-to-buffer (current-buffer))))
       (decode-coding-string (buffer-string) 'utf-8))))
 

--- a/wttrin.el
+++ b/wttrin.el
@@ -33,9 +33,9 @@
   :type '(list)
   )
 
-(defcustom wttrin-unit-system "m"
+(defcustom wttrin-unit-system nil
   "Specify the units.  use 'm' for 'metric', 'u' for 'USCS, or
-nil for location based"
+nil for location based units (the default)."
   :group 'wttrin
   :type 'string
   )


### PR DESCRIPTION
By default, wttr.in serves temperatures based on your location.  I'm in the states right now and don't want  to get my weather in Fahrenheit, so I added a variable to choose the unit system.

Relevant info for wttr.in is [here](https://github.com/chubin/wttr.in#additional-options).