### PR TITLE
fixed wttrin url request to return ASCII text rather than html

### DIFF
--- a/wttrin.el
+++ b/wttrin.el
@@ -33,15 +33,14 @@
   :type '(list)
   )
 
-(defun wttrin-fetch-raw-string (query)
-  "Get the weather information based on your QUERY."
-  (let ((url-request-extra-headers '(("User-Agent" . "curl"))))
-    (add-to-list 'url-request-extra-headers wttrin-default-accept-language)
-    (with-current-buffer
-        (url-retrieve-synchronously
-         (concat "http://wttr.in/" query)
-         (lambda (status) (switch-to-buffer (current-buffer))))
-      (decode-coding-string (buffer-string) 'utf-8))))
+(defun wttrin-fetch-raw-string (query) "Get the weather information based on your QUERY."
+       (let ((url-user-agent "curl"))
+	 (add-to-list 'url-request-extra-headers wttrin-default-accept-language)
+	 (with-current-buffer
+	     (url-retrieve-synchronously
+	      (concat "http://wttr.in/" query "?A")
+	      (lambda (status) (switch-to-buffer (current-buffer))))
+	   (decode-coding-string (buffer-string) 'utf-8))))
 
 (defun wttrin-exit ()
   (interactive)


### PR DESCRIPTION
wttrin.el started displaying HTML rather than ASCII this Spring. Seems to be due to a url request format change at wttrin.in. This patch fixes problem for me. 